### PR TITLE
use a different astropy logo format in the website sidebar

### DIFF
--- a/plugins/sidebar/sidebar.py
+++ b/plugins/sidebar/sidebar.py
@@ -40,7 +40,7 @@ class Sidebar(ConfigPlugin):
             final_text = u'<div class="sidebar">'
             now_2w = datetime.datetime.utcnow() - datetime.timedelta(weeks=2)
             now_2w = now_2w.replace(tzinfo=utc)
-            image = {'Astropy':'http://www.astropy.org/favicon.ico',
+            image = {'Astropy':'https://raw.githubusercontent.com/astropy/astropy-logo/master/astropy_logo_notext.svg',
                      'SunPy': 'https://cdn.rawgit.com/sunpy/sunpy-logo/master/generated/sunpy_icon.svg',
                      'Casacore': 'https://github.com/casacore.png?size=40',
                      'JuliaAstro': 'https://github.com/juliaastro.png?size=40',


### PR DESCRIPTION
![screen shot 2017-07-11 at 5 52 32 pm](https://user-images.githubusercontent.com/13077051/28097192-22e161d8-6663-11e7-99ed-dfda0ff8f897.png)

Opera is not happy with the current astropy logo format (``.ico``). ;-)