### PR TITLE
Pre gsoc21- Rachitt Shah blogposts

### DIFF
--- a/gsoc.yml
+++ b/gsoc.yml
@@ -20,7 +20,7 @@ gsoc2021:
   dhruv9vats:
     rss_feed: "https://medium.com/feed/@dhruv9vats"
     project: 'stingray'
-  godslayer201:
+  rachittshah:
     rss_feed: "https://medium.com/feed/@rachitt01"
     project: 'stingray'
   rashmiraj137:

--- a/gsoc.yml
+++ b/gsoc.yml
@@ -21,7 +21,7 @@ gsoc2021:
     rss_feed: "https://medium.com/feed/@dhruv9vats"
     project: 'stingray'
   godslayer201:
-    rss_feed: ""
+    rss_feed: "https://medium.com/feed/@rachitt01"
     project: 'stingray'
   rashmiraj137:
     rss_feed: "https://medium.com/feed/@raj-rashmi741"


### PR DESCRIPTION
Added my RSS feed for the gsoc blog posts for OpenAstronomy.

Files changed -
gsoc.yml

Content added -
rss_feed: "https://medium.com/feed/@rachitt01"